### PR TITLE
Refactor PRoST Loader POM

### DIFF
--- a/loader/pom.xml
+++ b/loader/pom.xml
@@ -11,18 +11,21 @@
 	<artifactId>PRoST-Loader</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
-	<name>PRoST-executor</name>
+	<name>PRoST-loader</name>
 	<url>https://maven.apache.org</url>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+                <hadoop.version>2.10.0</hadoop.version>
+                <scala.version>2.11</scala.version>
+                <spark.version>2.4.5</spark.version>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-rio-ntriples</artifactId>
-			<version>3.0.2</version>
+			<version>3.3.0-M2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
@@ -38,21 +41,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-core_2.11</artifactId>
-			<version>2.1.0</version>
+			<artifactId>spark-sql_${scala.version}</artifactId>
+			<version>${spark.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-sql_2.11</artifactId>
-			<version>2.1.0</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-hive_2.11</artifactId>
-			<version>2.1.0</version>
-			<scope>provided</scope>
+			<artifactId>spark-hive_${scala.version}</artifactId>
+			<version>${spark.version}</version>
+			<!-- <scope>provided</scope> -->
 		</dependency>
 		
 		<dependency>
@@ -64,26 +61,26 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>RELEASE</version>
+			<version>5.4.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>2.8.3</version>
+			<version>${hadoop.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.spark</groupId>
-			<artifactId>spark-catalyst_2.11</artifactId>
-			<version>2.1.0</version>
+			<artifactId>spark-catalyst_${scala.version}</artifactId>
+			<version>${spark.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.holdenkarau/spark-testing-base -->
 		<dependency>
 			<groupId>com.holdenkarau</groupId>
-			<artifactId>spark-testing-base_2.11</artifactId>
-			<version>2.2.0_0.10.0</version>
+			<artifactId>spark-testing-base_${scala.version}</artifactId>
+			<version>${spark.version}_0.14.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -106,7 +103,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.1.1</version>
 				<configuration>
 					<archive>
 						<manifest>
@@ -129,7 +126,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.1</version>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
- fixed <name> property
- Hadoop, Spark and Scala versions become parametric as maven properties
- upgraded com.holdenkarau.spark-testing-base_2.11 to 2.4.5_0.14.0
- upgrade maven-shade-plugin to 3.2.1 to take advantage of the 'minimizeJar" feature with JDK8+
- upgrade maven-assembly-plugin to 3.1.1
- removed spark-core dependency since it is a spark-sql dependency
- replaced the deprecated metaversion RELEASE value from junit-jupiter-api, with 5.4.2
- upgraded rdf4j-rio-ntriples to 3.3.0-M2 to receive performance and stability features